### PR TITLE
Add license headers to scripts

### DIFF
--- a/scripts/download_models.sh
+++ b/scripts/download_models.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
 
 set -e  # Exit on error
 

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,4 +1,8 @@
 #!/bin/bash -e
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set -e
 
 CHECK_ONLY=false


### PR DESCRIPTION
Adds Apache 2.0 license headers to shell scripts for proper attribution and compliance.