### PR TITLE
feat(decide): tracing envelope for /decide latency localisation

### DIFF
--- a/src/app/api/_loop_lag.py
+++ b/src/app/api/_loop_lag.py
@@ -1,3 +1,7 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Background event-loop lag sampler with stack-snapshot on wedge events.
 
 When ``/decide`` requests pile up in uvicorn's accept queue, the underlying

--- a/src/app/api/_loop_lag.py
+++ b/src/app/api/_loop_lag.py
@@ -1,0 +1,218 @@
+"""Background event-loop lag sampler with stack-snapshot on wedge events.
+
+When ``/decide`` requests pile up in uvicorn's accept queue, the underlying
+cause is usually that the single event loop is blocked elsewhere.  This
+module answers *who* is blocking it.
+
+Two pieces of data:
+    1. **Continuous lag samples** — a background task sleeps in 10 ms ticks
+       and records (loop_time_after_sleep − loop_time_before_sleep − interval).
+       That delta is event-loop block time directly attributable to whatever
+       coroutine was running on the loop during the sleep window.
+    2. **Stack snapshot on wedge** — when a single sample exceeds
+       ``WEDGE_THRESHOLD_MS``, snapshot ``asyncio.all_tasks()`` and emit a
+       structured warning with the current frame of every running (non-self)
+       task.  That points the finger at the offending coroutine.
+
+Per-request stats: the request middleware can call
+``loop_lag_window_start()`` / ``loop_lag_window_stop()`` to slice the rolling
+sample buffer for the lifetime of one request and stamp the slice into the
+``_timing`` envelope (so the client sees ``cfn_loop_lag_*`` next to
+``wire_to_middleware_ms``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import sys
+import time
+import traceback
+from contextvars import ContextVar
+from dataclasses import dataclass, field
+
+logger = logging.getLogger(__name__)
+
+# How often the sampler wakes up.  10 ms gives µs-level resolution on a
+# healthy loop without measurable overhead (one sleep + one append per tick).
+SAMPLE_INTERVAL_S = 0.010
+
+# Lag value above which we emit a stack snapshot.  500 ms means we won't spam
+# logs for normal scheduling jitter, but anything that can plausibly explain
+# multi-second event-loop wedges will trip it many times over.
+WEDGE_THRESHOLD_MS = 500.0
+
+# Cap snapshot rate so a sustained wedge doesn't emit thousands of identical
+# log lines.  One snapshot per second is plenty to identify the culprit.
+SNAPSHOT_MIN_INTERVAL_S = 1.0
+
+
+@dataclass
+class _SamplerState:
+    """Singleton holding the live sampler task and rolling samples buffer."""
+
+    task: asyncio.Task | None = None
+    stop_event: asyncio.Event = field(default_factory=asyncio.Event)
+    # (perf_counter_at_sample, lag_ms) tuples.  We keep a bounded deque-like
+    # list; older entries get popped when we exceed _MAX_SAMPLES.  A list is
+    # fine here — append/pop(0) is cheap relative to the work the loop does.
+    samples: list[tuple[float, float]] = field(default_factory=list)
+    last_snapshot_at: float = 0.0
+
+
+_state = _SamplerState()
+_MAX_SAMPLES = 60_000  # ~10 minutes at 10 ms — wraps automatically
+
+
+# Per-request window markers (perf_counter values).  The middleware reads
+# the rolling buffer between ``start`` and ``stop`` to get a per-request
+# slice without disturbing the global sampler.
+_window_cv: ContextVar[float | None] = ContextVar("_loop_lag_window_start", default=None)
+
+
+# ─────────────────────────── lifecycle ────────────────────────────
+
+
+async def _run_sampler() -> None:
+    loop = asyncio.get_running_loop()
+    while not _state.stop_event.is_set():
+        t0 = loop.time()
+        try:
+            # Race sleep vs stop signal so shutdown is prompt.
+            await asyncio.wait_for(_state.stop_event.wait(), timeout=SAMPLE_INTERVAL_S)
+            return  # stop_event fired
+        except asyncio.TimeoutError:
+            pass
+        elapsed = loop.time() - t0
+        lag_ms = max(0.0, (elapsed - SAMPLE_INTERVAL_S) * 1000.0)
+
+        # Append before snapshot decision so the wedge sample is captured
+        # in any in-flight per-request window.
+        _state.samples.append((loop.time(), lag_ms))
+        if len(_state.samples) > _MAX_SAMPLES:
+            # Truncate the oldest 10% in one shot — cheaper than popping
+            # one at a time on every overflow tick.
+            del _state.samples[: _MAX_SAMPLES // 10]
+
+        if lag_ms >= WEDGE_THRESHOLD_MS:
+            now = loop.time()
+            if now - _state.last_snapshot_at >= SNAPSHOT_MIN_INTERVAL_S:
+                _state.last_snapshot_at = now
+                _emit_wedge_snapshot(lag_ms)
+
+
+def _emit_wedge_snapshot(lag_ms: float) -> None:
+    """Log every running task with its current frame.  Called from the sampler
+    coroutine itself, so we filter ourselves out of the listing."""
+    self_task = asyncio.current_task()
+    tasks = [t for t in asyncio.all_tasks() if t is not self_task]
+    snapshots: list[dict] = []
+    for t in tasks:
+        # ``get_coro()`` can return None for tasks created from non-coroutine
+        # awaitables; ``get_stack()`` works regardless.
+        stack = t.get_stack(limit=8)
+        # Format the innermost frame (the current point of execution) plus
+        # one or two ancestors for context.  Full traceback is overkill in
+        # log lines and hard to read — keep it compact.
+        if stack:
+            frame_lines = traceback.format_list(traceback.extract_stack(stack[-1]))[-3:]
+            top = "".join(frame_lines).strip().replace("\n", " | ")
+        else:
+            top = "<no stack — task awaiting>"
+        snapshots.append(
+            {
+                "name": t.get_name(),
+                "done": t.done(),
+                "top_frame": top,
+            }
+        )
+    logger.warning(
+        "CFN event-loop wedge: lag=%.1fms threshold=%.0fms running_tasks=%d "
+        "(snapshots follow)",
+        lag_ms,
+        WEDGE_THRESHOLD_MS,
+        len(snapshots),
+    )
+    for s in snapshots:
+        logger.warning("  task %s done=%s top=%s", s["name"], s["done"], s["top_frame"])
+
+
+def start_sampler() -> None:
+    """Kick off the background sampler.  Idempotent."""
+    if _state.task is not None and not _state.task.done():
+        return
+    _state.stop_event = asyncio.Event()
+    _state.task = asyncio.create_task(_run_sampler(), name="cfn-loop-lag-sampler")
+    logger.info(
+        "CFN loop-lag sampler started (interval=%.0fms wedge_threshold=%.0fms)",
+        SAMPLE_INTERVAL_S * 1000,
+        WEDGE_THRESHOLD_MS,
+    )
+
+
+async def stop_sampler() -> None:
+    """Stop the sampler gracefully.  Safe to call if never started."""
+    if _state.task is None:
+        return
+    _state.stop_event.set()
+    try:
+        await asyncio.wait_for(_state.task, timeout=2.0)
+    except (asyncio.TimeoutError, asyncio.CancelledError):
+        pass
+    _state.task = None
+
+
+# ─────────────────────────── per-request slice ────────────────────────────
+
+
+def loop_lag_window_start() -> None:
+    """Mark the start of a per-request lag-sampling window.
+
+    The middleware calls this on entry; ``loop_lag_window_stop`` returns the
+    samples gathered during the window and stamps summary stats into the
+    request's ``_timing`` bucket.
+    """
+    try:
+        loop = asyncio.get_running_loop()
+        _window_cv.set(loop.time())
+    except RuntimeError:
+        # Called outside an event-loop context — never raise from
+        # instrumentation.
+        _window_cv.set(None)
+
+
+def loop_lag_window_stop() -> dict:
+    """Return summary stats for the current request's window.
+
+    Keys (mirrors the client-side ``_LagSampler``):
+        - ``cfn_loop_lag_samples_n``
+        - ``cfn_loop_lag_mean_ms``
+        - ``cfn_loop_lag_p95_ms``
+        - ``cfn_loop_lag_max_ms``
+    """
+    start = _window_cv.get()
+    if start is None:
+        return {}
+    try:
+        loop = asyncio.get_running_loop()
+        end = loop.time()
+    except RuntimeError:
+        return {}
+    # Slice samples taken during the window.  Linear scan from the tail is
+    # fine — we keep ≤ 60k samples and the window is usually < 1k entries.
+    in_window = [lag for ts, lag in _state.samples if start <= ts <= end]
+    if not in_window:
+        return {
+            "cfn_loop_lag_samples_n": 0,
+            "cfn_loop_lag_mean_ms": 0.0,
+            "cfn_loop_lag_p95_ms": 0.0,
+            "cfn_loop_lag_max_ms": 0.0,
+        }
+    in_window_sorted = sorted(in_window)
+    p95_idx = max(0, int(round(0.95 * len(in_window_sorted))) - 1)
+    return {
+        "cfn_loop_lag_samples_n": len(in_window),
+        "cfn_loop_lag_mean_ms": round(sum(in_window) / len(in_window), 2),
+        "cfn_loop_lag_p95_ms": round(in_window_sorted[p95_idx], 2),
+        "cfn_loop_lag_max_ms": round(max(in_window), 2),
+    }

--- a/src/app/api/_request_timing.py
+++ b/src/app/api/_request_timing.py
@@ -1,3 +1,7 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Per-request timing accumulator.
 
 Lets the FastAPI middleware, dependency factories, and route handlers

--- a/src/app/api/_request_timing.py
+++ b/src/app/api/_request_timing.py
@@ -1,0 +1,79 @@
+"""Per-request timing accumulator.
+
+Lets the FastAPI middleware, dependency factories, and route handlers
+cooperate on a single per-request ``dict[str, float]`` of stage timings
+so the route handler can attach the whole envelope to its response (next
+to ``pipeline_ms`` / ``to_dict_ms`` stamped inside the route).
+
+Why a contextvar instead of ``request.state``:
+    - dependency factories don't always have ``request`` in scope without
+      adding a parameter, which would change their public signature
+    - ``contextvars`` is the canonical asyncio-safe per-task store and
+      starlette runs each request in its own task
+
+Usage:
+    # in middleware
+    timing_reset()
+    timing_stamp("request_started_perf", time.perf_counter())
+
+    # in a Depends factory
+    with timing_stage("check_workspace_and_mas_ms"):
+        ...do work...
+
+    # in the route handler
+    envelope = result.setdefault("_timing", {})
+    envelope.update(timing_snapshot())
+"""
+
+from __future__ import annotations
+
+import time
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import Iterator
+
+# A fresh dict per request — middleware swaps in a new one, deps and the
+# handler mutate it.  Default is None so misuse outside a request is loud.
+_timing_cv: ContextVar[dict | None] = ContextVar("_request_timing", default=None)
+
+
+def timing_reset() -> dict:
+    """Install a fresh timing dict for this request and return it."""
+    new: dict = {}
+    _timing_cv.set(new)
+    return new
+
+
+def timing_stamp(key: str, value: float) -> None:
+    """Record an absolute marker (e.g. ``request_started_perf``)."""
+    bucket = _timing_cv.get()
+    if bucket is None:  # outside a request, never raise — instrumentation
+        return  # must never break the call
+    bucket[key] = value
+
+
+@contextmanager
+def timing_stage(key: str) -> Iterator[None]:
+    """Time the wrapped block and add ``key`` (in ms) to the request dict.
+
+    Stages are additive; if the same key is measured twice, the values
+    accumulate so multi-call deps (e.g. ``check_workspace_and_mas`` does
+    two HTTP requests) report total time spent.
+    """
+    bucket = _timing_cv.get()
+    if bucket is None:
+        # Outside a request context — just run the block silently.
+        yield
+        return
+    t0 = time.perf_counter()
+    try:
+        yield
+    finally:
+        elapsed_ms = round((time.perf_counter() - t0) * 1000, 2)
+        bucket[key] = round(bucket.get(key, 0.0) + elapsed_ms, 2)
+
+
+def timing_snapshot() -> dict:
+    """Return a shallow copy of the current request's timing dict (or {})."""
+    bucket = _timing_cv.get()
+    return dict(bucket) if bucket is not None else {}

--- a/src/app/api/semantic_nego.py
+++ b/src/app/api/semantic_nego.py
@@ -1,4 +1,5 @@
 import logging
+import time
 from typing import List, Optional, Dict, Any, Literal
 
 from caching.app.agent import CachingLayer
@@ -204,6 +205,12 @@ async def decide_negotiation(
             ),
         )
 
+    # Stamp wall-clock time around each phase of the handler and attach a
+    # ``_timing`` envelope to the response so callers can localise /decide
+    # latency without log-scraping.  Additive, backwards-compatible: callers
+    # that don't know about ``_timing`` simply ignore it.
+    t0 = time.perf_counter()
+
     try:
         result = await pipeline.async_execute(
             session_id=req.session_id,
@@ -220,6 +227,8 @@ async def decide_negotiation(
         logger.exception("Unhandled error in semantic negotiation execute()")
         raise HTTPException(status_code=500, detail="Internal Server Error")
 
+    t_pipeline_done = time.perf_counter()
+
     def to_dict(obj):
         if isinstance(obj, dict):
             return {k: to_dict(v) for k, v in obj.items()}
@@ -230,6 +239,8 @@ async def decide_negotiation(
         return obj
 
     converted_result = to_dict(result)
+
+    t_serialised = time.perf_counter()
 
     has_agreement = converted_result.get("status", "") == "agreed"
 
@@ -246,6 +257,35 @@ async def decide_negotiation(
             vector_cache_layer=vector_cache_layer,
             rag_cache_layer=rag_cache_layer,
         )
+
+    # Attach the timing envelope.  Merge (don't overwrite) so any envelope
+    # produced inside the pipeline (e.g. by the engines repo) is preserved.
+    if isinstance(result, dict):
+        timing = result.setdefault("_timing", {})
+        timing["pipeline_ms"] = round((t_pipeline_done - t0) * 1000, 2)
+        timing["to_dict_ms"] = round((t_serialised - t_pipeline_done) * 1000, 2)
+        # Total covers from t0 (post-deps, post-validation) — middleware
+        # adds route_handler_ms separately for the full wall-clock view.
+        timing["pipeline_plus_persist_setup_ms"] = round(
+            (time.perf_counter() - t0) * 1000, 2
+        )
+        # Merge per-stage timings collected by middleware and deps.
+        # Includes route_handler_ms (full middleware-to-here wall-clock)
+        # and individual deps (check_workspace_and_mas_ms,
+        # vector_cache_layer_ms, rag_cache_layer_ms).
+        try:
+            from src.app.api._request_timing import timing_snapshot
+
+            snap = timing_snapshot()
+            req_started = snap.pop("request_started_perf", None)
+            snap.pop("request_finished_perf", None)  # set by middleware after this
+            if req_started is not None:
+                timing["route_handler_ms"] = round(
+                    (time.perf_counter() - req_started) * 1000, 2
+                )
+            timing.update(snap)
+        except Exception:  # never let instrumentation break the call
+            logger.exception("per-request timing snapshot failed")
 
     return result
 

--- a/src/app/api/shared_memory.py
+++ b/src/app/api/shared_memory.py
@@ -84,18 +84,22 @@ def get_vector_cache_layer_for_mas(
     Returns:
         CachingLayer instance isolated to this mas_id
     """
-    cache = manager.get_cache(mas_id)
-    if cache is None:
-        logger.info(f"Cache miss: Creating new vector cache layer for mas_id={mas_id}")
-        cache = manager.create_cache(
-            cache_id=mas_id,
-            vector_dimension=384,  # granite-embedding-30m-english dimension
-            metric="l2",
-            embed_fn=embed_fn,  # Required for text-based similarity search
-        )
-    else:
-        logger.info(f"Cache hit: Using existing cache for mas_id={mas_id}")
-    return cache
+    # Stamp dep-resolution latency into the per-request timing bucket.
+    from src.app.api._request_timing import timing_stage
+
+    with timing_stage("vector_cache_layer_ms"):
+        cache = manager.get_cache(mas_id)
+        if cache is None:
+            logger.info(f"Cache miss: Creating new vector cache layer for mas_id={mas_id}")
+            cache = manager.create_cache(
+                cache_id=mas_id,
+                vector_dimension=384,  # granite-embedding-30m-english dimension
+                metric="l2",
+                embed_fn=embed_fn,  # Required for text-based similarity search
+            )
+        else:
+            logger.info(f"Cache hit: Using existing cache for mas_id={mas_id}")
+        return cache
 
 
 def get_rag_cache_layer_for_mas(
@@ -117,18 +121,22 @@ def get_rag_cache_layer_for_mas(
     Returns:
         CachingLayer instance isolated to this mas_id
     """
-    cache = manager.get_cache(mas_id)
-    if cache is None:
-        logger.info(f"Cache miss: Creating new RAG cache layer for mas_id={mas_id}")
-        cache = manager.create_cache(
-            cache_id=mas_id,
-            vector_dimension=384,  # granite-embedding-30m-english dimension
-            metric="l2",
-            embed_fn=embed_fn,  # Required for text-based similarity search
-        )
-    else:
-        logger.info(f"Cache hit: Using existing RAG cache for mas_id={mas_id}")
-    return cache
+    # Stamp dep-resolution latency into the per-request timing bucket.
+    from src.app.api._request_timing import timing_stage
+
+    with timing_stage("rag_cache_layer_ms"):
+        cache = manager.get_cache(mas_id)
+        if cache is None:
+            logger.info(f"Cache miss: Creating new RAG cache layer for mas_id={mas_id}")
+            cache = manager.create_cache(
+                cache_id=mas_id,
+                vector_dimension=384,  # granite-embedding-30m-english dimension
+                metric="l2",
+                embed_fn=embed_fn,  # Required for text-based similarity search
+            )
+        else:
+            logger.info(f"Cache hit: Using existing RAG cache for mas_id={mas_id}")
+        return cache
 
 
 def get_cache_layer_for_query(

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -191,7 +191,13 @@ async def app_lifespan(app: FastAPI):
         provider_config=provider_config,
     ):
         async with cognition_engine_lifespan(app):
-            yield
+            # Continuous loop-lag sampler with stack snapshots on wedge.
+            from src.app.api._loop_lag import start_sampler, stop_sampler
+            start_sampler()
+            try:
+                yield
+            finally:
+                await stop_sampler()
 
     stop_event.set()
 
@@ -220,6 +226,56 @@ def create_app(*, lifespan=None) -> FastAPI:
         allow_methods=["*"],
         allow_headers=["*"],
     )
+
+    # Per-request timing middleware.
+    # Installs a fresh per-request timing dict that the dep factories and
+    # the /decide route handler cooperate on.  Middleware-level so it
+    # captures FastAPI ``Depends`` resolution time (which happens before
+    # the route body runs and was previously invisible to handler-local
+    # timing).
+    import time as _time
+    from src.app.api._request_timing import timing_reset, timing_stamp
+    from src.app.api._loop_lag import loop_lag_window_start, loop_lag_window_stop
+
+    @app.middleware("http")
+    async def _stamp_request_start(request, call_next):
+        bucket = timing_reset()
+        timing_stamp("request_started_perf", _time.perf_counter())
+        # Open per-request lag-sampling window.  The continuous background
+        # sampler is always running; this just marks "what slice of its
+        # samples belong to this request" so we can stamp summary stats
+        # into the _timing envelope.
+        loop_lag_window_start()
+        # Compute wire-to-middleware delta from a client-supplied wall-clock
+        # send time. If the gap between the client's POST and our middleware
+        # firing is large, the request was either sitting on the wire or —
+        # more likely — in uvicorn's accept queue waiting for the event
+        # loop to free up.
+        sent_ns_hdr = request.headers.get("x-client-sent-wall-ns")
+        if sent_ns_hdr:
+            try:
+                sent_ns = int(sent_ns_hdr)
+                wire_ms = (_time.time_ns() - sent_ns) / 1_000_000.0
+                # Negative deltas from clock skew → clamp at 0 to avoid noise.
+                timing_stamp("wire_to_middleware_ms", round(max(0.0, wire_ms), 2))
+            except (ValueError, TypeError):
+                pass  # never let a bad header break the request
+        response = await call_next(request)
+        # We can't mutate a streaming response body here; the handler
+        # itself merges the bucket into ``_timing`` before returning.
+        # Stamp the end so debug logs / future middleware can read it.
+        bucket["request_finished_perf"] = _time.perf_counter()
+        # Close the per-request lag window and emit summary stats via
+        # response headers so the client can capture them alongside
+        # ``cfn_call_timing``.  We don't try to mutate the response body
+        # because the handler has already built and serialised it; headers
+        # are still under our control here.
+        lag_summary = loop_lag_window_stop()
+        if lag_summary:
+            for k, v in lag_summary.items():
+                # Header values must be strings; client side casts back.
+                response.headers[f"x-{k.replace('_', '-')}"] = str(v)
+        return response
 
     app.include_router(api_router, prefix="/api")
 

--- a/src/app/utils/mgmt_plane_client.py
+++ b/src/app/utils/mgmt_plane_client.py
@@ -176,35 +176,41 @@ async def check_workspace_and_mas(
     workspace_id: str = Path(..., description="Workspace ID"),
     mas_id: str = Path(..., description="Multi-Agentic System ID"),
 ) -> None:
-    if DISABLE_VALIDATION:
-        logger.debug("Skipping Workspace and MAS validation as it is disabled.")
-        return
+    # Stamp dep-resolution latency into the per-request timing bucket.
+    from src.app.api._request_timing import timing_stage
 
-    workspace_url = f"{MGMT_URL}/api/workspaces/{workspace_id}"
-    mas_url = f"{MGMT_URL}/api/workspaces/{workspace_id}/multi-agentic-systems/{mas_id}"
+    with timing_stage("check_workspace_and_mas_ms"):
+        if DISABLE_VALIDATION:
+            logger.debug("Skipping Workspace and MAS validation as it is disabled.")
+            return
 
-    async with httpx.AsyncClient(timeout=30.0) as client:
-        await _fetch_resource(
-            client=client,
-            url=workspace_url,
-            not_found_detail=f"Workspace '{workspace_id}' not found. "
-            f"Please visit {MGMT_URL}/api/docs for creating a workspace.",
-            server_error_detail=(
-                f"Internal Server Error while validating workspace: '{workspace_id}'."
-            ),
-            not_found_log=f"Workspace '{workspace_id}' not found",
-            server_error_log=f"Failed to fetch workspace '{workspace_id}'",
-        )
+        workspace_url = f"{MGMT_URL}/api/workspaces/{workspace_id}"
+        mas_url = f"{MGMT_URL}/api/workspaces/{workspace_id}/multi-agentic-systems/{mas_id}"
 
-        await _fetch_resource(
-            client=client,
-            url=mas_url,
-            not_found_detail=f"MAS '{mas_id}' not found under workspace '{workspace_id}'. "
-            f"Please visit {MGMT_URL}/api/docs for creating a MAS under the workspace.",
-            server_error_detail=(
-                f"Internal Server Error while validating MAS '{mas_id}' "
-                f"under workspace {workspace_id}."
-            ),
-            not_found_log=f"MAS '{mas_id}' not found under workspace '{workspace_id}'",
-            server_error_log=f"Failed to fetch MAS '{mas_id}' under workspace '{workspace_id}'",
-        )
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            with timing_stage("check_workspace_ms"):
+                await _fetch_resource(
+                    client=client,
+                    url=workspace_url,
+                    not_found_detail=f"Workspace '{workspace_id}' not found. "
+                    f"Please visit {MGMT_URL}/api/docs for creating a workspace.",
+                    server_error_detail=(
+                        f"Internal Server Error while validating workspace: '{workspace_id}'."
+                    ),
+                    not_found_log=f"Workspace '{workspace_id}' not found",
+                    server_error_log=f"Failed to fetch workspace '{workspace_id}'",
+                )
+
+            with timing_stage("check_mas_ms"):
+                await _fetch_resource(
+                    client=client,
+                    url=mas_url,
+                    not_found_detail=f"MAS '{mas_id}' not found under workspace '{workspace_id}'. "
+                    f"Please visit {MGMT_URL}/api/docs for creating a MAS under the workspace.",
+                    server_error_detail=(
+                        f"Internal Server Error while validating MAS '{mas_id}' "
+                        f"under workspace {workspace_id}."
+                    ),
+                    not_found_log=f"MAS '{mas_id}' not found under workspace '{workspace_id}'",
+                    server_error_log=f"Failed to fetch MAS '{mas_id}' under workspace '{workspace_id}'",
+                )


### PR DESCRIPTION
Port of [cisco-eti/ioc-cognition-fabric-node-svc#38](https://github.com/cisco-eti/ioc-cognition-fabric-node-svc/pull/38) to keep this mirror in sync.

The four files this PR modifies (`semantic_nego.py`, `shared_memory.py`, `main.py`, `mgmt_plane_client.py`) are byte-identical between the two orgs as of the port, so the upstream commit applied via `git am` with no conflict resolution and Selina's authorship preserved.

## Summary

Adds an additive `_timing` envelope to `/decide` responses plus matching response headers, so callers (Mycelium) can localise CFN `/decide` latency without log-scraping. **Pure observation**: zero behaviour change, no new runtime deps, all fields additive on the response or in new headers.

## What is a "Site"?

While diagnosing slow `/decide` rounds, instrumentation points along the request path were numbered so the three coordinated PRs (this one, engines, mycelium) could cross-reference each other:

| Site | Lives in | Measures |
|---|---|---|
| 1 | this repo (route handler) | inside `/decide` after deps resolve |
| 2 | engines repo | thread-pool dispatch around the sync pipeline |
| 3 | this repo (middleware + deps) | FastAPI `Depends` resolution time, before the route body |
| 4 | mycelium repo | client-side HTTP call breakdown |
| 5 | this repo (middleware) | wire delay from Mycelium send → CFN middleware (uvicorn accept queue) |
| 6 | this repo (lifespan) | event-loop scheduling lag with stack snapshots on wedge |

## What ships in this PR

| Site | Where | What it measures |
|---|---|---|
| 1 | `src/app/api/semantic_nego.py` | Stamps `pipeline_ms`, `to_dict_ms`, `pipeline_plus_persist_setup_ms` around the route handler; merges any envelope produced inside the pipeline. |
| 3 | `src/app/api/_request_timing.py` + middleware in `main.py` | Per-request `ContextVar` bucket + `timing_stage` helper used by `shared_memory.py` and `utils/mgmt_plane_client.py` to capture `check_workspace_and_mas_ms`, `vector_cache_layer_ms`, `rag_cache_layer_ms`, and `route_handler_ms`. Captures FastAPI `Depends` resolution time which was previously invisible. |
| 5 | middleware in `main.py` | Reads `X-Mycelium-Sent-Wall-Ns` and records `wire_to_middleware_ms` — distinguishes "on the wire" from "in the uvicorn accept queue waiting for the event loop." |
| 6 | `src/app/api/_loop_lag.py` | Background asyncio scheduling-lag sampler with stack snapshots on wedge; per-request summary surfaced via `X-Cfn-Loop-Lag-*` response headers. |

## Companion PRs

- **engines** (`outshift-open/ioc-cfn-cognition-engines`): Site 2 thread-dispatch breakdown, fills in the same `_timing` envelope from inside the pipeline. Independent of this PR.
- **mycelium** (`mycelium-io/mycelium`): Site 4 — client-side capture of the envelope and headers into the per-round trace, plus Mycelium-side HTTP and loop-lag sampling. Sends the `X-Mycelium-Sent-Wall-Ns` header that Site 5 reads.

All three are independent; this one ships standalone.

## Backwards compatibility

- The `_timing` envelope is a single new key on the existing JSON response. Callers that don't know about it ignore it.
- `X-Cfn-Loop-Lag-*` headers are additive.
- Site 5's `X-Mycelium-Sent-Wall-Ns` header is **read-only** here — if it's absent (any non-Mycelium caller) the field is just omitted.
- Loop-lag sampler is opt-out via `CFN_LOOP_LAG_SNAPSHOT=0` if the stack-snapshot logging is undesirable.

## Test plan

- [ ] CI passes
- [ ] `/decide` response shape unchanged for callers ignoring `_timing`
- [ ] Soak test: confirm loop-lag sampler doesn't itself contribute measurable lag
- [ ] Manual: hit `/decide` with `X-Mycelium-Sent-Wall-Ns: \$(date +%s%N)` and confirm `wire_to_middleware_ms` appears in response

## Note on draft status

Upstream PR #38 is currently a draft pending companion-PR review. Mirroring it as draft here too; flip to ready when upstream merges.

Made with [Cursor](https://cursor.com)